### PR TITLE
cancel polling timeouts on route change

### DIFF
--- a/app/scripts/dashboard/controllers.js
+++ b/app/scripts/dashboard/controllers.js
@@ -51,17 +51,23 @@ function ($scope, $location, $statistic, $designImageService, $dashboardUtilsSer
     (function tick(){
         $statistic.getVisits().then(function (data) {
             $scope.visitStats = data;
-            $timeout(tick, pollingRate);
+            $scope.visitTimeout = $timeout(tick, pollingRate);
         });
     })();
+    $scope.$on('$locationChangeStart', function() {
+      $timeout.cancel($scope.visitTimeout);
+    });
 
     // Sales Stats
     (function tick(){
         $statistic.getSales().then(function (data) {
             $scope.salesStats = data;
-            $timeout(tick, pollingRate);
+            $scope.salesTimeout = $timeout(tick, pollingRate);
         });
     })();
+    $scope.$on('$locationChangeStart', function() {
+      $timeout.cancel($scope.salesTimeout);
+    });
 
     // Highcharts settings that we can't adjust from ngHighcharts
     Highcharts.setOptions({


### PR DESCRIPTION
polling was continuing on new routes, so i guess we need to destroy them when you change routes away.
