### PR TITLE
[#95669418 Finish] Show order item options in a more variable way

### DIFF
--- a/app/themes/views/order/edit.html
+++ b/app/themes/views/order/edit.html
@@ -17,132 +17,135 @@
 <h3 class="text-center">Date: <strong>{{getDate();}}</strong></h3>
 <hr>
 
-<!-- bill to table -->
-<div class="col-sm-5 col-sm-offset-1 col-xs-12 col-xs-offset-0">
-    <h3 class="text-center">
-        Billing Address
-    </h3>
+<div class="row">
+    <!-- bill to table -->
+    <div class="col-sm-6">
+        <h3>
+            Billing Address
+        </h3>
 
-    <!-- bill to info -->
-    <table class="table table-bordered order-details">
-        <tr class="text-left">
-            <td><strong>Company:</strong></td>
-            <td>{{order.billing_address.company}}</td>
-        </tr>
-        <tr class="text-left">
-            <td><strong>Name:</strong></td>
-            <td>{{order.billing_address.last_name}} {{order.billing_address.first_name}}</td>
-        </tr>
-        <tr class="text-left">
-            <td><strong>Address:</strong></td>
-            <td>{{order.billing_address.address_line1}} {{order.billing_address.address_line2}}, {{order.billing_address.city}}</td>
-        </tr>
-        <tr class="text-left">
-            <td><strong>Zip,state,country:</strong></td>
-            <td>{{order.billing_address.zip_code}}, {{order.billing_address.state}}, {{order.billing_address.country}}</td>
-        </tr>
-        <tr class="text-left">
-            <td><strong>Phone:</strong></td>
-            <td>{{order.billing_address.phone}}</td>
-        </tr>
-    </table>
+        <!-- bill to info -->
+        <table class="table table-bordered order-details">
+            <tr>
+                <td><strong>Company:</strong></td>
+                <td>{{order.billing_address.company}}</td>
+            </tr>
+            <tr>
+                <td><strong>Name:</strong></td>
+                <td>{{order.billing_address.last_name}}, {{order.billing_address.first_name}}</td>
+            </tr>
+            <tr>
+                <td><strong>Address:</strong></td>
+                <td>{{order.billing_address.address_line1}} {{order.billing_address.address_line2}}, {{order.billing_address.city}}</td>
+            </tr>
+            <tr>
+                <td><strong>Zip,state,country:</strong></td>
+                <td>{{order.billing_address.zip_code}}, {{order.billing_address.state}}, {{order.billing_address.country}}</td>
+            </tr>
+            <tr>
+                <td><strong>Phone:</strong></td>
+                <td>{{order.billing_address.phone}}</td>
+            </tr>
+        </table>
+    </div>
+
+    <!-- ship to table -->
+    <div class="col-sm-6">
+        <h3>
+            Shipping Address
+        </h3>
+
+        <!-- ship to info -->
+        <table class="table table-bordered order-details">
+            <tr>
+                <td><strong>Company:</strong></td>
+                <td>{{order.shipping_address.company}}</td>
+            </tr>
+            <tr>
+                <td><strong>Name:</strong></td>
+                <td>{{order.shipping_address.last_name}}, {{order.shipping_address.first_name}}</td>
+            </tr>
+            <tr>
+                <td><strong>Address:</strong></td>
+                <td>{{order.shipping_address.address_line1}} {{order.shipping_address.address_line2}}, {{order.shipping_address.city}},</td>
+            </tr>
+            <tr>
+                <td><strong>Zip,state,country:</strong></td>
+                <td>{{order.shipping_address.zip_code}}, {{order.shipping_address.state}}, {{order.shipping_address.country}}</td>
+            </tr>
+            <tr>
+                <td><strong>Phone:</strong></td>
+                <td>{{order.shipping_address.phone}}</td>
+            </tr>
+        </table>
+    </div>
 </div>
 
-<!-- ship to table -->
-<div class="col-sm-5 col-xs-12">
-    <h3 class="text-center">
-        Shipping Address
-    </h3>
+<div class="row">
+    <div class="col-lg-6">
+        <!-- order table -->
+        <h3>Order Items</h3>
 
-    <!-- ship to info -->
-    <table class="table table-bordered order-details">
-        <tr>
-            <td style="width: 60%"><strong>Company:</strong></td>
-            <td>{{order.shipping_address.company}}</td>
-        </tr>
-        <tr>
-            <td style="width: 60%"><strong>Name:</strong></td>
-            <td>{{order.shipping_address.last_name}} {{order.shipping_address.first_name}}</td>
-        </tr>
-        <tr>
-            <td style="width: 60%"><strong>Address:</strong></td>
-            <td>{{order.shipping_address.address_line1}} {{order.shipping_address.address_line2}}, {{order.shipping_address.city}},</td>
-        </tr>
-        <tr>
-            <td style="width: 60%"><strong>Zip,state,country:</strong></td>
-            <td>{{order.shipping_address.zip_code}}, {{order.shipping_address.state}}, {{order.shipping_address.country}}</td>
-        </tr>
-        <tr>
-            <td style="width: 60%"><strong>Phone:</strong></td>
-            <td>{{order.shipping_address.phone}}</td>
-        </tr>
-    </table>
+        <table class="table table-bordered table-striped order-details">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>SKU</th>
+                    <th>Options</th> <!-- dynamic options -->
+                    <th>Quantity</th>
+                    <th>Price</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="product in order.items">
+
+                    <!-- product name -->
+                    <td>{{product.Name}}</td>
+
+                    <!-- product sku -->
+                    <td>{{product.Sku}}</td>
+
+                    <!-- dynamic options -->
+                    <td>
+                        <div ng-repeat="option in product.Options">
+                            {{ option.label }}: {{ option.value }}
+                        </div>
+                    </td>
+
+                    <!-- product quantity -->
+                    <td>{{product.Qty}}</td>
+
+                    <!-- product price -->
+                    <td>{{product.Price | currency}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="col-lg-6">
+        <!-- total table -->
+        <h3>Order Totals</h3>
+
+        <table class="table table-bordered table-striped order-details">
+            <tr>
+                <th>Subtotal:</th>
+                <td class="text-right">{{order.subtotal | currency}}</td>
+            </tr>
+            <tr>
+                <th>Shipping:</th>
+                <td class="text-right">{{order.shipping_amount | currency}}</td>
+            </tr>
+            <tr>
+                <th>Tax:</th>
+                <td class="text-right">{{order.tax_amount | currency}}</td>
+            </tr>
+            <tr>
+                <th>Order Total:</th>
+                <td class="text-right"><strong>{{order.grand_total | currency}}</strong></td>
+            </tr>
+        </table>
+    </div>
 </div>
-
-<div class="clearfix"></div>
-
-<!-- order table -->
-<div class="col-sm-5 col-sm-offset-1 col-xs-12 col-xs-offset-0">
-    <h3 class="text-center">
-       Order Items
-    </h3>
-
-    <table class="table table-bordered text-left order-details">
-        <tr >
-            <td class="text-left" style="width: 25%"><strong>Name</strong></td>
-            <td class="text-left" style="width: 20%"><strong>SKU</strong></td>
-            <td class="text-center"><strong>Size</strong></td>
-            <td class="text-center"><strong>Quantity</strong></td>
-            <td class="text-center"><strong>Price</strong></td>
-
-        </tr>
-        <tr ng-repeat="product in order.items">
-
-            <!-- product name -->
-            <td class="text-left" style="width: 25%">{{product.Name}}</td>
-
-            <!-- product sku -->
-            <td class="text-left" style="width: 20%">{{product.Sku}}</td>
-
-            <!-- product size -->
-            <td class="text-center" ng-show="product.Options.Size.value != null">{{product.Options.Size.value}}</td>
-
-            <!-- product quantity -->
-            <td class="text-center">{{product.Qty}}</td>
-
-            <!-- product price -->
-            <td class="text-right">{{product.Price | currency}}</td>
-        </tr>
-    </table>
-</div>
-
-<!-- total table -->
-<div class="col-sm-5 col-xs-12">
-    <h3 class="text-center">
-       Order Totals
-    </h3>
-
-    <table class="table table-bordered text-left order-details">
-        <tr>
-            <td class="text-left" style="width: 60%"><strong>Subtotal:</strong></td>
-            <td class="text-right">{{order.subtotal | currency}}</td>
-        </tr>
-        <tr>
-            <td><strong>Shipping:</strong></td>
-            <td class="text-right" style="width: 60%">{{order.shipping_amount | currency}}</td>
-        </tr>
-        <tr>
-            <td class="text-left"><strong>Tax:</strong></td>
-            <td class="text-right" style="width: 60%">{{order.tax_amount | currency}}</td>
-        </tr>
-        <tr>
-            <td class="text-left"><strong>Order Total:</strong></td>
-            <td class="text-right" style="width: 60%">{{order.grand_total | currency}}</td>
-        </tr>
-    </table>
-</div>
-
-<div class="clearfix"></div>
 
 <label class="col-xs-12 col-sm-4 col-sm-offset-4">Change status
     <select class="form-control" name="status" id="status" ng-model="order.status"


### PR DESCRIPTION
# Details
- replaced named "Size" column with  "Options" column, that dynamically matches up any order item option labels and values
- touched the responsive aspects a little to make it a little more legible.
# Notes about options format

I had already added this to an icebox section of Foundation, but the organization for item options could really use some TLC https://www.pivotaltracker.com/story/show/93816626 

```
{
  "OrderID": "555ed5e388a87b39d4000109",
  "ProductID": "5511ff1dd4a2560a1400001a",
  "Qty": 1,
  "Name": "Lip Whip - Naked - 7ml",
  "Sku": "KGLWPN",
  "ShortDescription": "",
  "Options": {
    "Flavor": {
      "label": "Flavor",
      "options": {
        "Peppermint": {
          "label": "Peppermint",
          "order": 1,
          "price": "15.00",
          "sku": "KGLWPN"
        }
      },
      "order": 1,
      "required": true,
      "type": "select",
      "value": "Peppermint"
    }
  },
  "Price": 15,
  "Weight": 0
}
```
