### PR TITLE
make the loading bar smaller

### DIFF
--- a/app/scripts/dashboard/loading-bar/loading.provider.js
+++ b/app/scripts/dashboard/loading-bar/loading.provider.js
@@ -10,7 +10,7 @@ angular.module("dashboardModule")
     this.spinnerTemplate = '<div id="loading-bar-spinner"><div class="spinner-icon"></div></div>';
     this.loadingBarTemplate = '<div id="loading-bar">'+
       '<div class="progress">'+
-        '<div class="progress-bar progress-bar-striped active" >'+
+        '<div class="progress-bar active" >'+
         '</div>'+
       '</div>'+
     '</div>';

--- a/app/themes/styles/loading-bar.scss
+++ b/app/themes/styles/loading-bar.scss
@@ -2,9 +2,6 @@
 #loading-bar-spinner {
   pointer-events: none;
   -webkit-pointer-events: none;
-  -webkit-transition: 350ms linear all;
-  -moz-transition: 350ms linear all;
-  -o-transition: 350ms linear all;
   transition: 350ms linear all;
 }
 
@@ -29,15 +26,16 @@
   left: 0;
   width: 100%;
   height: inherit;
-}
 
-#loading-bar .progress-bar {
-  -webkit-transition: width 350ms;
-  -moz-transition: width 350ms;
-  -o-transition: width 350ms;
-  transition: width 350ms;
-}
+  .progress {
+    border-radius: 0;
+    height: 3px;
 
+    .progress-bar {
+      transition: width 350ms;
+    }
+  }
+}
 
 /* Fancy blur effect */
 #loading-bar .peg {
@@ -47,13 +45,8 @@
   top: 0;
   height: 2px;
   opacity: .45;
-  -moz-box-shadow: #29d 1px 0 6px 1px;
-  -ms-box-shadow: #29d 1px 0 6px 1px;
-  -webkit-box-shadow: #29d 1px 0 6px 1px;
   box-shadow: #29d 1px 0 6px 1px;
-  -moz-border-radius: 100%;
-  -webkit-border-radius: 100%;
-  border-radius: 100%;
+  border-radius: 0;
 }
 
 #loading-bar-spinner {
@@ -62,23 +55,20 @@
   z-index: 10002;
   top: 10px;
   left: 10px;
+
+  .spinner-icon {
+    width: 14px;
+    height: 14px;
+
+    border:  solid 2px transparent;
+    border-top-color:  #29d;
+    border-left-color: #29d;
+    border-radius: 10px;
+
+    animation:         loading-bar-spinner 400ms linear infinite;
+  }
 }
 
-#loading-bar-spinner .spinner-icon {
-  width: 14px;
-  height: 14px;
-
-  border:  solid 2px transparent;
-  border-top-color:  #29d;
-  border-left-color: #29d;
-  border-radius: 10px;
-
-  -webkit-animation: loading-bar-spinner 400ms linear infinite;
-  -moz-animation:    loading-bar-spinner 400ms linear infinite;
-  -ms-animation:     loading-bar-spinner 400ms linear infinite;
-  -o-animation:      loading-bar-spinner 400ms linear infinite;
-  animation:         loading-bar-spinner 400ms linear infinite;
-}
 
 @-webkit-keyframes loading-bar-spinner {
   0%   { -webkit-transform: rotate(0deg);   transform: rotate(0deg); }


### PR DESCRIPTION
I know you were annoyed by this too, so i thought i'd fix it real quick
- made it smaller (3px)
- no striping animation
- square ends
