### PR TITLE
[#95909804] gulp-rev-all for dashboard

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,10 +11,10 @@ var sass = require('gulp-sass');
 var del = require('del');
 var concat = require('gulp-concat');
 var sourcemaps = require('gulp-sourcemaps');
-// var ngAnnotate = require('gulp-ng-annotate');
-// var notify = require('gulp-notify');
 var refresh = require('gulp-livereload');
 var modRewrite = require('connect-modrewrite');
+var RevAll = require('gulp-rev-all');
+var runSequence = require('run-sequence');
 
 
 var paths = {
@@ -244,11 +244,32 @@ gulp.task('watch',function(){
     gulp.watch(paths.watch.lib,      ['lib.scripts']);
 });
 
+gulp.task('revision', function(){
+	if(env === 'production') {
+		var revAll = new RevAll({
+			dontUpdateReference: [/^((?!.js|.css).)*$/g],
+			dontRenameFile: [/^((?!.js|.css).)*$/g]
+		});
+		gulp.src('dist/**')
+			.pipe(revAll.revision())
+			.pipe(gulp.dest('dist'));
+	}
+});
+
+
 gulp.task('lib', ['lib.copy','lib.scripts']);
 
 gulp.task('themes', ['themes.copy','themes.scripts','themes.styles','themes.fonts','themes.images']);
 
-gulp.task('build', ['scripts', 'html','lib','themes','misc']);
+gulp.task('build', function(){
+	runSequence('clean', [
+		'scripts',
+		'html',
+		'lib',
+		'themes',
+		'misc'
+	], 'revision');
+});
 
 gulp.task('default', ['build'] ,function(){
     gulp.start('watch');

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "gulp-minify-css": "^0.3.13",
     "gulp-minify-html": "^0.1.8",
     "gulp-ng-annotate": "^0.5.2",
+    "gulp-rev-all": "^0.8.21",
     "gulp-sass": "^2.0.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-strip-debug": "^1.0.2",
-    "gulp-uglify": "^0.3.2"
+    "gulp-uglify": "^0.3.2",
+    "run-sequence": "^1.1.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Same as for storefronts, rename .css, .js, and sourcemaps.
