### PR TITLE
[#90437940] Fix Attributes

### DIFF
--- a/app/scripts/product/controller/attributeEdit.js
+++ b/app/scripts/product/controller/attributeEdit.js
@@ -36,7 +36,7 @@ function ($scope, $routeParams, $location, $productApiService, $dashboardUtilsSe
 
     $scope.attribute = {};
     $scope.attributesList = [];
-    $scope.typesAttribute = ["id", "boolean", "integer", "text", "json", "decimal", "datetime", "[]id", "[]integer", "[]text"];
+    $scope.typesAttribute = ["id", "boolean", "int", "text", "json", "decimal", "datetime", "[]id", "[]integer", "[]text"];
     $scope.editorsList = [
         "text",
         "multiline_text",

--- a/app/scripts/visitor/controller/attributeEdit.js
+++ b/app/scripts/visitor/controller/attributeEdit.js
@@ -29,7 +29,7 @@ function ($scope, $routeParams, $location, $visitorApiService, $dashboardUtilsSe
 
     $scope.attribute = {};
     $scope.attributesList = [];
-    $scope.typesAttribute = ["integer", "real", "text"];
+    $scope.typesAttribute = ["int", "float", "text"];
     $scope.editorsList = [
         "not_editable",
         "text",


### PR DESCRIPTION
The problem was Foundation has const="int", Dashboard has const="integer" in Product and Visitor attributes.
Also Visitor attributes has "real" but foundation doesn't have it, so replaced to "float".

Foundation types definition - https://github.com/ottemo/foundation/blob/b2b97f426d32696db252764f8895ec2622c447a2/utils/datatypes.go
