### PR TITLE
[#101685510 Deliver] grid pagination bug

### DIFF
--- a/app/scripts/design/directives/guiTableManager.js
+++ b/app/scripts/design/directives/guiTableManager.js
@@ -442,6 +442,7 @@ angular.module("designModule")
                     if (limit) {
                         parts = limit.split(",");
                         page = Math.floor(parts[0] / countPerPage) + 1;
+                        countPerPage = parts[1];
                     }
                     $scope.paginator = {
                         "page": page,


### PR DESCRIPTION
- the paginator defaulted to the global limit instead of looking at
  what was applied in the url / init
## testing notes
- the orders page now doesn't show any pagination because they have fewer than 50 orders
- you can change the limit in the url to 20 though, and then use the paging buttons, and see that the limit is maintained
- grids on other pages continue to work.
