### PR TITLE
Show option labels on Subscription details page

### DIFF
--- a/src/app/subscriptions/edit.html
+++ b/src/app/subscriptions/edit.html
@@ -32,8 +32,15 @@
                             <td>{{ product.name }}</td>
                             <td>{{ product.sku }}</td>
                             <td>
-                                <div ng-repeat="(label, value) in product.options">
-                                    {{ label }}: {{ value }}
+                                <div ng-if="subscription.info && subscription.info.options">
+                                     <div ng-repeat="(optionLabel, optionValueLabel) in subscription.info.options">
+                                         {{ optionLabel }}: {{ optionValueLabel }}
+                                     </div>
+                                </div>
+                                <div ng-if="!(subscription.info && subscription.info.options)">
+                                    <div ng-repeat="(label, value) in product.options">
+                                        {{ label }}: {{ value }}
+                                    </div>
                                 </div>
                             </td>
                             <td>{{ product.price | currency }}</td>


### PR DESCRIPTION
Accordingly to ottemo/foundation#370
Tries to get option labels from subscription.info. 
Shows option keys, if no labels are provided. In this case we should update subscription info in DB by API call `subscriptionsupdate/info/:id`
